### PR TITLE
Automatically copy emojis to the clipboard

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -24,12 +24,31 @@ function saveCustomEmojis(emojiBlob) {
   });
 };
 
+// Copying requires a visible, mounted text input.
+function copyToClipboard(text) {
+  var input = document.createElement('input');
+  input.style.opacity = 0;
+  document.body.appendChild(input);
+
+  input.value = text;
+  input.focus();
+  input.select();
+
+  // Copying can fail on occasion.
+  try {
+    document.execCommand('copy');
+  } catch (error) {}
+
+  input.remove();
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   getCustomEmojis(function (customEmoji) {
     var completeEmojiList = EMOJILIST.concat(customEmoji);
     var randomEmoji = pickEmoji(completeEmojiList);
     var emojiDiv = document.getElementById('emoji');
     emojiDiv.innerHTML = randomEmoji;
+    copyToClipboard(randomEmoji);
   });
 });
 


### PR DESCRIPTION
As soon as you click the extension icon, the emoji name is automatically copied to your system clipboard.

Caveat: this doesn't work in FireFox. Calling `execCommand` with clipboard arguments isn't allowed outside a user-generated event. Supposedly the `clipboardWrite` permission fixes it, but I've had no such luck.